### PR TITLE
Replaced channels.list call with conversations.list 

### DIFF
--- a/handlers/aws_sns_to_slack_publisher.py
+++ b/handlers/aws_sns_to_slack_publisher.py
@@ -69,7 +69,7 @@ class SnsPublishError(HandlerBaseError):
 def _check_slack_channel_exists(token: str, channel: str) -> None:
     '''Check given Slack channel exists'''
     r = SLACK.api_call(
-        "channels.list",
+        "conversations.list",
         token=token,
     )
     _logger.debug('Slack response: {}'.format(json.dumps(r)))


### PR DESCRIPTION
Addresses #3 

The Slack API call to `channels.list` currently fails with new Slack applications.

In Feb 2021 it will stop working for all Slack apps.  The response returned will be:

`{
    "ok": false,
    "error": "method_deprecated"
}`

This new call to `conversations.list` should be transparent aside from the API call itself.